### PR TITLE
Added blurb and link for 2FA and app specific passwords

### DIFF
--- a/config/smtp_config_gmail.rst
+++ b/config/smtp_config_gmail.rst
@@ -24,3 +24,9 @@ enable *“Allow users to manage their access to less secure apps”*.
 Now that you've done that, **or if you are not a G Suite user**, you'll
 need to enable the setting for *“less secure
 apps”* here: https://myaccount.google.com/lesssecureapps
+
+Please note that if you are using Google's two-factor authenticaion,
+then you will NOT be able to enable the "less secure apps" setting. 
+Instead, you will need to create an "app specific password". For more 
+information and details on how to configure app specific passwords, 
+please visit https://support.google.com/accounts/answer/185833?hl=en.


### PR DESCRIPTION
Gmail users with 2FA will not be able to enable "less secure apps." Therefore, they must create app specific passwords. 